### PR TITLE
update go toolchain to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/minio/minio
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.6
 
 // Install tools using 'go install tool'.
 tool (


### PR DESCRIPTION
## Description

Bump go toolchain version to 1.24.6 to resolve several CVEs:

- CVE-2025-4674 [HIGH]
- CVE-2025-47907 [HIGH]
- CVE-2025-4673 [MED]


